### PR TITLE
feat: add error for not extracting and running msu launcher

### DIFF
--- a/scripts/!mods_preload/msu-launcher-not-extracted.nut
+++ b/scripts/!mods_preload/msu-launcher-not-extracted.nut
@@ -1,0 +1,1 @@
+::Hooks.errorAndQuit("The downloaded msu-launcher.zip file must not be placed inside the BB data folder. Instead extract it somewhere outside and then run MSULauncher.exe. Then it will create its own ~mod_msu_launcher.zip file in your data folder which will be correct. For details, follow the Instructions for Users on the MSU Launcher NexusMods page.");


### PR DESCRIPTION
Many users just download the zip file and put it in their data folder and don't actually extract it and run the launcher. This error message notifies the user about this mistake and what to do about it.